### PR TITLE
Add calorie & macro tracker web app

### DIFF
--- a/calorie-tracker/css/style.css
+++ b/calorie-tracker/css/style.css
@@ -1,0 +1,289 @@
+:root {
+  --bg: #f4f6f8;
+  --card-bg: #ffffff;
+  --primary: #2e7d32;
+  --primary-dark: #1b5e20;
+  --accent: #ef6c00;
+  --text: #263238;
+  --muted: #78909c;
+  --border: #e0e4e8;
+  --danger: #c62828;
+  --over: #d32f2f;
+  --good: #2e7d32;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.topbar {
+  background: var(--primary-dark);
+  color: white;
+  padding: 1rem 1.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.topbar h1 {
+  margin: 0 0 0.75rem 0;
+  font-size: 1.4rem;
+}
+
+.tabs {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.tab-btn {
+  background: rgba(255,255,255,0.12);
+  border: none;
+  color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.95rem;
+  transition: background 0.15s;
+}
+
+.tab-btn:hover { background: rgba(255,255,255,0.25); }
+.tab-btn.active { background: var(--primary); font-weight: 600; }
+
+main {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 1.25rem;
+}
+
+.tab-panel { display: none; }
+.tab-panel.active { display: block; }
+
+.card {
+  background: var(--card-bg);
+  border-radius: 10px;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.25rem;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+}
+
+.card h2 {
+  margin-top: 0;
+  font-size: 1.1rem;
+  color: var(--primary-dark);
+}
+
+.hint { font-size: 0.8rem; color: var(--muted); font-weight: normal; }
+
+.panel-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.panel-header label { font-weight: 600; }
+
+.panel-header input[type="date"] {
+  padding: 0.4rem 0.6rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+
+.targets-summary {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.section-card {
+  background: var(--card-bg);
+  border-radius: 10px;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1rem;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+}
+
+.section-card h3 {
+  margin: 0 0 0.6rem 0;
+  color: var(--primary-dark);
+  font-size: 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.section-card .section-subtotal {
+  font-size: 0.8rem;
+  color: var(--muted);
+  font-weight: normal;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+th, td {
+  padding: 0.4rem 0.5rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+}
+
+th { color: var(--muted); font-weight: 600; font-size: 0.8rem; text-transform: uppercase; }
+
+.table-scroll { overflow-x: auto; }
+
+.food-row select,
+.food-row input[type="number"] {
+  width: 100%;
+  padding: 0.3rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+
+.food-row .qty-cell { width: 90px; }
+.food-row .unit-cell { width: 60px; color: var(--muted); }
+
+.remove-btn, .delete-btn {
+  background: none;
+  border: none;
+  color: var(--danger);
+  cursor: pointer;
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.add-row-btn {
+  margin-top: 0.5rem;
+  background: var(--primary);
+  color: white;
+  border: none;
+  padding: 0.4rem 0.9rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.add-row-btn:hover { background: var(--primary-dark); }
+
+button {
+  font-family: inherit;
+}
+
+#save-height-btn, #add-weight-btn, #add-measurement-btn, #add-food-btn, #save-targets-btn {
+  background: var(--primary);
+  color: white;
+  border: none;
+  padding: 0.45rem 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+#save-height-btn:hover, #add-weight-btn:hover, #add-measurement-btn:hover,
+#add-food-btn:hover, #save-targets-btn:hover { background: var(--primary-dark); }
+
+.inline-form {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.inline-form input {
+  padding: 0.4rem 0.6rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+
+.combo {
+  display: flex;
+  gap: 4px;
+  flex-wrap: nowrap;
+}
+.combo input { width: 45px; }
+
+.measurements-table input, #food-form-row input {
+  width: 70px;
+  padding: 0.25rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+#food-form-row input[data-field="name"] { width: 140px; }
+#food-form-row input[data-field="unit"] { width: 50px; }
+
+.targets-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.targets-form label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.8rem;
+  color: var(--muted);
+  gap: 0.25rem;
+}
+
+.targets-form input {
+  padding: 0.35rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  width: 90px;
+}
+
+.macro-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.macro-bar-row {
+  display: grid;
+  grid-template-columns: 80px 1fr 110px;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.85rem;
+}
+
+.bar-track {
+  background: var(--border);
+  border-radius: 6px;
+  height: 10px;
+  overflow: hidden;
+}
+
+.bar-fill {
+  height: 100%;
+  background: var(--primary);
+  transition: width 0.3s;
+}
+
+.bar-fill.over { background: var(--over); }
+.bar-fill.in-range { background: var(--good); }
+
+.totals-table .target-row td { color: var(--muted); font-style: italic; }
+
+.summary-table td.over { color: var(--over); font-weight: 600; }
+.summary-table td.good { color: var(--good); font-weight: 600; }
+
+footer {
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.8rem;
+  padding: 1rem;
+}
+
+@media (max-width: 700px) {
+  .macro-bar-row { grid-template-columns: 60px 1fr 90px; font-size: 0.75rem; }
+  table { font-size: 0.8rem; }
+}

--- a/calorie-tracker/index.html
+++ b/calorie-tracker/index.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Calorie & Macro Tracker</title>
+<link rel="stylesheet" href="css/style.css" />
+</head>
+<body>
+<header class="topbar">
+  <h1>Calorie &amp; Macro Tracker</h1>
+  <nav class="tabs">
+    <button class="tab-btn active" data-tab="meals">Meal Builder</button>
+    <button class="tab-btn" data-tab="summary">7-Day Summary</button>
+    <button class="tab-btn" data-tab="health">Health Data</button>
+    <button class="tab-btn" data-tab="foods">Food Database</button>
+  </nav>
+</header>
+
+<main>
+  <!-- ============ MEAL BUILDER ============ -->
+  <section id="tab-meals" class="tab-panel active">
+    <div class="panel-header">
+      <label for="meal-date">Date:</label>
+      <input type="date" id="meal-date" />
+      <div class="targets-summary" id="targets-readout"></div>
+    </div>
+
+    <div id="sections-container"></div>
+
+    <div class="day-total card">
+      <h2>Day Total</h2>
+      <div id="day-total-bars" class="macro-bars"></div>
+      <table class="totals-table">
+        <thead>
+          <tr><th></th><th>Calories</th><th>Protein</th><th>Carb</th><th>Fat</th><th>Fiber</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Total</td>
+            <td id="tot-cal">0</td>
+            <td id="tot-protein">0</td>
+            <td id="tot-carb">0</td>
+            <td id="tot-fat">0</td>
+            <td id="tot-fiber">0</td>
+          </tr>
+          <tr class="target-row">
+            <td>Target</td>
+            <td id="target-cal">-</td>
+            <td id="target-protein">-</td>
+            <td id="target-carb">-</td>
+            <td id="target-fat">-</td>
+            <td id="target-fiber">-</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- ============ 7-DAY SUMMARY ============ -->
+  <section id="tab-summary" class="tab-panel">
+    <div class="card">
+      <h2>Last 7 Days</h2>
+      <div class="table-scroll">
+        <table class="summary-table" id="summary-table">
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Calories</th>
+              <th>Protein (g)</th>
+              <th>Carb (g)</th>
+              <th>Fat (g)</th>
+              <th>Fiber (g)</th>
+            </tr>
+          </thead>
+          <tbody id="summary-body"></tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ HEALTH DATA ============ -->
+  <section id="tab-health" class="tab-panel">
+    <div class="card">
+      <h2>Height (static)</h2>
+      <div class="inline-form">
+        <input type="text" id="height-input" placeholder="e.g. 5' 7&quot; or 170 cm" />
+        <button id="save-height-btn">Save</button>
+      </div>
+    </div>
+
+    <div class="card">
+      <h2>Daily Weight</h2>
+      <div class="inline-form">
+        <input type="date" id="weight-date" />
+        <input type="number" step="0.1" id="weight-input" placeholder="Weight (lbs/kg)" />
+        <button id="add-weight-btn">Add / Update</button>
+      </div>
+      <div class="table-scroll">
+        <table class="data-table" id="weight-table">
+          <thead><tr><th>Date</th><th>Weight</th><th></th></tr></thead>
+          <tbody id="weight-body"></tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="card">
+      <h2>Body Measurements (fortnightly)</h2>
+      <div class="table-scroll">
+        <table class="data-table measurements-table" id="measurements-table">
+          <thead>
+            <tr>
+              <th>Date</th><th>Chest</th><th>Biceps (L/R)</th><th>Hips</th><th>Thighs (R/L)</th>
+              <th>Neck</th><th>Forearm (R/L)</th><th>Wrist (R/L)</th><th>Shoulder</th>
+              <th>Waist</th><th>Pant</th><th>Belly</th><th>Weight</th><th>BFP</th><th></th>
+            </tr>
+          </thead>
+          <tbody id="measurements-body"></tbody>
+          <tfoot>
+            <tr id="measurement-form-row">
+              <td><input type="date" data-field="date" /></td>
+              <td><input type="number" step="0.01" data-field="chest" /></td>
+              <td class="combo"><input type="number" step="0.01" data-field="bicepsL" placeholder="L" /><input type="number" step="0.01" data-field="bicepsR" placeholder="R" /></td>
+              <td><input type="number" step="0.01" data-field="hips" /></td>
+              <td class="combo"><input type="number" step="0.01" data-field="thighR" placeholder="R" /><input type="number" step="0.01" data-field="thighL" placeholder="L" /></td>
+              <td><input type="number" step="0.01" data-field="neck" /></td>
+              <td class="combo"><input type="number" step="0.01" data-field="forearmR" placeholder="R" /><input type="number" step="0.01" data-field="forearmL" placeholder="L" /></td>
+              <td class="combo"><input type="number" step="0.01" data-field="wristR" placeholder="R" /><input type="number" step="0.01" data-field="wristL" placeholder="L" /></td>
+              <td><input type="number" step="0.01" data-field="shoulder" /></td>
+              <td><input type="number" step="0.01" data-field="waist" /></td>
+              <td><input type="number" step="0.01" data-field="pant" /></td>
+              <td><input type="number" step="0.01" data-field="belly" /></td>
+              <td><input type="number" step="0.01" data-field="weight" /></td>
+              <td><input type="number" step="0.01" data-field="bfp" /></td>
+              <td><button id="add-measurement-btn">Add</button></td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ FOOD DATABASE ============ -->
+  <section id="tab-foods" class="tab-panel">
+    <div class="card">
+      <h2>Food Database <span class="hint">(values per 1 unit shown)</span></h2>
+      <div class="table-scroll">
+        <table class="data-table" id="food-table">
+          <thead>
+            <tr>
+              <th>Name</th><th>Unit</th><th>Calories</th><th>Protein</th><th>Carb</th><th>Fat</th><th>Fiber</th><th>Sugar</th><th></th>
+            </tr>
+          </thead>
+          <tbody id="food-body"></tbody>
+          <tfoot>
+            <tr id="food-form-row">
+              <td><input type="text" data-field="name" placeholder="Food name" /></td>
+              <td><input type="text" data-field="unit" placeholder="gm" value="gm" /></td>
+              <td><input type="number" step="0.00001" data-field="cal" /></td>
+              <td><input type="number" step="0.00001" data-field="protein" /></td>
+              <td><input type="number" step="0.00001" data-field="carb" /></td>
+              <td><input type="number" step="0.00001" data-field="fat" /></td>
+              <td><input type="number" step="0.00001" data-field="fiber" /></td>
+              <td><input type="number" step="0.00001" data-field="sugar" /></td>
+              <td><button id="add-food-btn">Add</button></td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </div>
+
+    <div class="card">
+      <h2>Daily Targets</h2>
+      <div class="targets-form">
+        <label>Calories <input type="number" id="t-calorie" /></label>
+        <label>Protein (g) <input type="number" id="t-protein" /></label>
+        <label>Carb (g) <input type="number" id="t-carb" /></label>
+        <label>Fat min (g) <input type="number" id="t-fatmin" /></label>
+        <label>Fat max (g) <input type="number" id="t-fatmax" /></label>
+        <label>Fiber min (g) <input type="number" id="t-fibermin" /></label>
+        <label>Fiber max (g) <input type="number" id="t-fibermax" /></label>
+        <button id="save-targets-btn">Save Targets</button>
+      </div>
+    </div>
+  </section>
+</main>
+
+<footer>
+  <p>All data is stored locally in your browser (localStorage).</p>
+</footer>
+
+<script src="js/foods.js"></script>
+<script src="js/storage.js"></script>
+<script src="js/app.js"></script>
+</body>
+</html>

--- a/calorie-tracker/js/app.js
+++ b/calorie-tracker/js/app.js
@@ -1,0 +1,503 @@
+// ===================== Helpers =====================
+function todayStr() {
+  const d = new Date();
+  return d.toISOString().slice(0, 10);
+}
+
+function fmt(n, decimals = 1) {
+  if (n === null || n === undefined || isNaN(n)) return "0";
+  return Number(n).toFixed(decimals).replace(/\.0$/, "");
+}
+
+function getFoodByName(name) {
+  return Store.getFoods().find((f) => f.name === name);
+}
+
+function computeRowMacros(row) {
+  const food = getFoodByName(row.food);
+  const qty = Number(row.qty) || 0;
+  if (!food) return { cal: 0, protein: 0, carb: 0, fat: 0, fiber: 0, sugar: 0 };
+  return {
+    cal: food.cal * qty,
+    protein: food.protein * qty,
+    carb: food.carb * qty,
+    fat: food.fat * qty,
+    fiber: food.fiber * qty,
+    sugar: food.sugar * qty,
+  };
+}
+
+function computeDayTotals(dayMeals) {
+  const totals = { cal: 0, protein: 0, carb: 0, fat: 0, fiber: 0, sugar: 0 };
+  SECTIONS.forEach((section) => {
+    (dayMeals[section] || []).forEach((row) => {
+      const m = computeRowMacros(row);
+      totals.cal += m.cal;
+      totals.protein += m.protein;
+      totals.carb += m.carb;
+      totals.fat += m.fat;
+      totals.fiber += m.fiber;
+      totals.sugar += m.sugar;
+    });
+  });
+  return totals;
+}
+
+function computeSectionTotals(rows) {
+  const totals = { cal: 0, protein: 0, carb: 0, fat: 0, fiber: 0 };
+  rows.forEach((row) => {
+    const m = computeRowMacros(row);
+    totals.cal += m.cal;
+    totals.protein += m.protein;
+    totals.carb += m.carb;
+    totals.fat += m.fat;
+    totals.fiber += m.fiber;
+  });
+  return totals;
+}
+
+// ===================== Tabs =====================
+function initTabs() {
+  document.querySelectorAll(".tab-btn").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      document.querySelectorAll(".tab-btn").forEach((b) => b.classList.remove("active"));
+      document.querySelectorAll(".tab-panel").forEach((p) => p.classList.remove("active"));
+      btn.classList.add("active");
+      document.getElementById(`tab-${btn.dataset.tab}`).classList.add("active");
+      if (btn.dataset.tab === "summary") renderSummary();
+      if (btn.dataset.tab === "health") renderHealth();
+      if (btn.dataset.tab === "foods") renderFoods();
+    });
+  });
+}
+
+// ===================== Meal Builder =====================
+let currentDate = todayStr();
+
+function initMealBuilder() {
+  const dateInput = document.getElementById("meal-date");
+  dateInput.value = currentDate;
+  dateInput.addEventListener("change", () => {
+    currentDate = dateInput.value || todayStr();
+    renderMealBuilder();
+  });
+  renderTargetsReadout();
+  renderMealBuilder();
+}
+
+function renderTargetsReadout() {
+  const t = Store.getTargets();
+  document.getElementById("targets-readout").textContent =
+    `Target: ${t.calorie} kcal | Protein ${t.protein}g | Carb ${t.carb}g | Fat ${t.fatMin}-${t.fatMax}g | Fiber ${t.fiberMin}-${t.fiberMax}g`;
+}
+
+function renderMealBuilder() {
+  const container = document.getElementById("sections-container");
+  container.innerHTML = "";
+  const dayMeals = Store.getDayMeals(currentDate);
+  const foods = Store.getFoods();
+
+  SECTIONS.forEach((section) => {
+    const card = document.createElement("div");
+    card.className = "section-card";
+
+    const subtotal = computeSectionTotals(dayMeals[section]);
+    card.innerHTML = `
+      <h3>${section} <span class="section-subtotal">${fmt(subtotal.cal)} kcal | P ${fmt(subtotal.protein)} | C ${fmt(subtotal.carb)} | F ${fmt(subtotal.fat)} | Fib ${fmt(subtotal.fiber)}</span></h3>
+      <table>
+        <thead>
+          <tr><th>Food</th><th>Qty</th><th>Unit</th><th>Cal</th><th>Protein</th><th>Carb</th><th>Fat</th><th>Fiber</th><th></th></tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+      <button class="add-row-btn">+ Add food</button>
+    `;
+
+    const tbody = card.querySelector("tbody");
+    dayMeals[section].forEach((row, idx) => {
+      tbody.appendChild(buildFoodRow(section, idx, row, foods));
+    });
+
+    card.querySelector(".add-row-btn").addEventListener("click", () => {
+      const dm = Store.getDayMeals(currentDate);
+      dm[section].push({ food: foods[0] ? foods[0].name : "", qty: 0 });
+      Store.setDayMeals(currentDate, dm);
+      renderMealBuilder();
+    });
+
+    container.appendChild(card);
+  });
+
+  renderDayTotals(dayMeals);
+}
+
+function buildFoodRow(section, idx, row, foods) {
+  const tr = document.createElement("tr");
+  tr.className = "food-row";
+
+  const food = getFoodByName(row.food) || foods[0];
+  const macros = computeRowMacros(row);
+
+  const select = document.createElement("select");
+  foods.forEach((f) => {
+    const opt = document.createElement("option");
+    opt.value = f.name;
+    opt.textContent = f.name;
+    if (f.name === row.food) opt.selected = true;
+    select.appendChild(opt);
+  });
+  select.addEventListener("change", () => {
+    const dm = Store.getDayMeals(currentDate);
+    dm[section][idx].food = select.value;
+    Store.setDayMeals(currentDate, dm);
+    renderMealBuilder();
+  });
+
+  const qtyInput = document.createElement("input");
+  qtyInput.type = "number";
+  qtyInput.step = "any";
+  qtyInput.value = row.qty || "";
+  qtyInput.className = "qty-cell";
+  qtyInput.addEventListener("input", () => {
+    const dm = Store.getDayMeals(currentDate);
+    dm[section][idx].qty = Number(qtyInput.value) || 0;
+    Store.setDayMeals(currentDate, dm);
+    // update only the macro cells + totals, avoid full re-render for smooth typing
+    const updated = computeRowMacros(dm[section][idx]);
+    tr.querySelector(".cal-cell").textContent = fmt(updated.cal);
+    tr.querySelector(".protein-cell").textContent = fmt(updated.protein);
+    tr.querySelector(".carb-cell").textContent = fmt(updated.carb);
+    tr.querySelector(".fat-cell").textContent = fmt(updated.fat);
+    tr.querySelector(".fiber-cell").textContent = fmt(updated.fiber);
+    renderSectionSubtotalsAndTotals();
+  });
+
+  const tdFood = document.createElement("td");
+  tdFood.appendChild(select);
+
+  const tdQty = document.createElement("td");
+  tdQty.appendChild(qtyInput);
+
+  const tdUnit = document.createElement("td");
+  tdUnit.className = "unit-cell";
+  tdUnit.textContent = food ? food.unit : "";
+
+  const tdCal = document.createElement("td");
+  tdCal.className = "cal-cell";
+  tdCal.textContent = fmt(macros.cal);
+
+  const tdProtein = document.createElement("td");
+  tdProtein.className = "protein-cell";
+  tdProtein.textContent = fmt(macros.protein);
+
+  const tdCarb = document.createElement("td");
+  tdCarb.className = "carb-cell";
+  tdCarb.textContent = fmt(macros.carb);
+
+  const tdFat = document.createElement("td");
+  tdFat.className = "fat-cell";
+  tdFat.textContent = fmt(macros.fat);
+
+  const tdFiber = document.createElement("td");
+  tdFiber.className = "fiber-cell";
+  tdFiber.textContent = fmt(macros.fiber);
+
+  const tdRemove = document.createElement("td");
+  const removeBtn = document.createElement("button");
+  removeBtn.className = "remove-btn";
+  removeBtn.textContent = "✕";
+  removeBtn.title = "Remove";
+  removeBtn.addEventListener("click", () => {
+    const dm = Store.getDayMeals(currentDate);
+    dm[section].splice(idx, 1);
+    Store.setDayMeals(currentDate, dm);
+    renderMealBuilder();
+  });
+  tdRemove.appendChild(removeBtn);
+
+  tr.append(tdFood, tdQty, tdUnit, tdCal, tdProtein, tdCarb, tdFat, tdFiber, tdRemove);
+  return tr;
+}
+
+// Lightweight refresh of subtotals/totals without rebuilding the whole DOM (used while typing qty)
+function renderSectionSubtotalsAndTotals() {
+  const dayMeals = Store.getDayMeals(currentDate);
+  document.querySelectorAll(".section-card").forEach((card, i) => {
+    const section = SECTIONS[i];
+    const subtotal = computeSectionTotals(dayMeals[section]);
+    card.querySelector(".section-subtotal").textContent =
+      `${fmt(subtotal.cal)} kcal | P ${fmt(subtotal.protein)} | C ${fmt(subtotal.carb)} | F ${fmt(subtotal.fat)} | Fib ${fmt(subtotal.fiber)}`;
+  });
+  renderDayTotals(dayMeals);
+}
+
+function renderDayTotals(dayMeals) {
+  const totals = computeDayTotals(dayMeals);
+  const t = Store.getTargets();
+
+  document.getElementById("tot-cal").textContent = fmt(totals.cal);
+  document.getElementById("tot-protein").textContent = fmt(totals.protein);
+  document.getElementById("tot-carb").textContent = fmt(totals.carb);
+  document.getElementById("tot-fat").textContent = fmt(totals.fat);
+  document.getElementById("tot-fiber").textContent = fmt(totals.fiber);
+
+  document.getElementById("target-cal").textContent = t.calorie;
+  document.getElementById("target-protein").textContent = t.protein;
+  document.getElementById("target-carb").textContent = t.carb;
+  document.getElementById("target-fat").textContent = `${t.fatMin}-${t.fatMax}`;
+  document.getElementById("target-fiber").textContent = `${t.fiberMin}-${t.fiberMax}`;
+
+  const barsContainer = document.getElementById("day-total-bars");
+  barsContainer.innerHTML = "";
+  barsContainer.appendChild(makeBar("Calories", totals.cal, 0, t.calorie, t.calorie));
+  barsContainer.appendChild(makeBar("Protein", totals.protein, 0, t.protein, t.protein));
+  barsContainer.appendChild(makeBar("Carb", totals.carb, 0, t.carb, t.carb));
+  barsContainer.appendChild(makeBar("Fat", totals.fat, t.fatMin, t.fatMax, t.fatMax));
+  barsContainer.appendChild(makeBar("Fiber", totals.fiber, t.fiberMin, t.fiberMax, t.fiberMax));
+}
+
+// Builds a labeled progress bar row. `min`/`max` define the "good" range; `scaleMax` is the bar's 100% point.
+function makeBar(label, value, min, max, scaleMax) {
+  const row = document.createElement("div");
+  row.className = "macro-bar-row";
+
+  const pct = Math.min(100, (value / scaleMax) * 100);
+  const inRange = value >= min && value <= max;
+  const over = value > max;
+
+  let cls = "bar-fill";
+  if (over) cls += " over";
+  else if (inRange) cls += " in-range";
+
+  row.innerHTML = `
+    <span>${label}</span>
+    <div class="bar-track"><div class="${cls}" style="width:${pct}%"></div></div>
+    <span>${fmt(value)} / ${min === max ? max : `${min}-${max}`}</span>
+  `;
+  return row;
+}
+
+// ===================== 7-Day Summary =====================
+function renderSummary() {
+  const tbody = document.getElementById("summary-body");
+  tbody.innerHTML = "";
+  const t = Store.getTargets();
+  const meals = Store.getMeals();
+
+  for (let i = 6; i >= 0; i--) {
+    const d = new Date();
+    d.setDate(d.getDate() - i);
+    const dateStr = d.toISOString().slice(0, 10);
+    const dayMeals = meals[dateStr] || {};
+    const totals = computeDayTotals(
+      SECTIONS.reduce((acc, s) => ({ ...acc, [s]: dayMeals[s] || [] }), {})
+    );
+
+    const tr = document.createElement("tr");
+    const calClass = totals.cal > t.calorie * 1.05 ? "over" : totals.cal > 0 ? "good" : "";
+    const protClass = totals.protein >= t.protein ? "good" : "";
+    const fatClass = totals.fat > t.fatMax ? "over" : (totals.fat >= t.fatMin && totals.fat > 0 ? "good" : "");
+    const fiberClass = totals.fiber > t.fiberMax ? "over" : (totals.fiber >= t.fiberMin && totals.fiber > 0 ? "good" : "");
+
+    tr.innerHTML = `
+      <td>${dateStr}${dateStr === todayStr() ? " (today)" : ""}</td>
+      <td class="${calClass}">${fmt(totals.cal)}</td>
+      <td class="${protClass}">${fmt(totals.protein)}</td>
+      <td>${fmt(totals.carb)}</td>
+      <td class="${fatClass}">${fmt(totals.fat)}</td>
+      <td class="${fiberClass}">${fmt(totals.fiber)}</td>
+    `;
+    tbody.appendChild(tr);
+  }
+}
+
+// ===================== Health Data =====================
+function renderHealth() {
+  document.getElementById("height-input").value = Store.getHeight();
+
+  document.getElementById("weight-date").value = todayStr();
+
+  renderWeightTable();
+  renderMeasurementsTable();
+}
+
+function renderWeightTable() {
+  const weights = Store.getWeights();
+  const tbody = document.getElementById("weight-body");
+  tbody.innerHTML = "";
+  Object.keys(weights)
+    .sort((a, b) => (a < b ? 1 : -1))
+    .forEach((date) => {
+      const tr = document.createElement("tr");
+      tr.innerHTML = `<td>${date}</td><td>${weights[date]}</td><td><button class="delete-btn" data-date="${date}">✕</button></td>`;
+      tr.querySelector(".delete-btn").addEventListener("click", () => {
+        const w = Store.getWeights();
+        delete w[date];
+        Store.saveWeights(w);
+        renderWeightTable();
+      });
+      tbody.appendChild(tr);
+    });
+}
+
+const MEASUREMENT_FIELDS = [
+  "date", "chest", "bicepsL", "bicepsR", "hips", "thighR", "thighL", "neck",
+  "forearmR", "forearmL", "wristR", "wristL", "shoulder", "waist", "pant", "belly", "weight", "bfp",
+];
+
+function renderMeasurementsTable() {
+  const list = Store.getMeasurements();
+  const tbody = document.getElementById("measurements-body");
+  tbody.innerHTML = "";
+  list
+    .slice()
+    .sort((a, b) => (a.date < b.date ? 1 : -1))
+    .forEach((m) => {
+      const tr = document.createElement("tr");
+      tr.innerHTML = `
+        <td>${m.date}</td>
+        <td>${m.chest ?? ""}</td>
+        <td>${m.bicepsL ?? ""}/${m.bicepsR ?? ""}</td>
+        <td>${m.hips ?? ""}</td>
+        <td>${m.thighR ?? ""}/${m.thighL ?? ""}</td>
+        <td>${m.neck ?? ""}</td>
+        <td>${m.forearmR ?? ""}/${m.forearmL ?? ""}</td>
+        <td>${m.wristR ?? ""}/${m.wristL ?? ""}</td>
+        <td>${m.shoulder ?? ""}</td>
+        <td>${m.waist ?? ""}</td>
+        <td>${m.pant ?? ""}</td>
+        <td>${m.belly ?? ""}</td>
+        <td>${m.weight ?? ""}</td>
+        <td>${m.bfp ?? ""}</td>
+        <td><button class="delete-btn" data-date="${m.date}">✕</button></td>
+      `;
+      tr.querySelector(".delete-btn").addEventListener("click", () => {
+        const updated = Store.getMeasurements().filter((x) => x.date !== m.date);
+        Store.saveMeasurements(updated);
+        renderMeasurementsTable();
+      });
+      tbody.appendChild(tr);
+    });
+}
+
+function initHealthForms() {
+  document.getElementById("save-height-btn").addEventListener("click", () => {
+    Store.saveHeight(document.getElementById("height-input").value.trim());
+    alert("Height saved.");
+  });
+
+  document.getElementById("add-weight-btn").addEventListener("click", () => {
+    const date = document.getElementById("weight-date").value;
+    const value = document.getElementById("weight-input").value;
+    if (!date || value === "") return;
+    const weights = Store.getWeights();
+    weights[date] = Number(value);
+    Store.saveWeights(weights);
+    document.getElementById("weight-input").value = "";
+    renderWeightTable();
+  });
+
+  document.getElementById("add-measurement-btn").addEventListener("click", () => {
+    const row = document.getElementById("measurement-form-row");
+    const entry = {};
+    MEASUREMENT_FIELDS.forEach((f) => {
+      const input = row.querySelector(`[data-field="${f}"]`);
+      const v = input.value;
+      entry[f] = f === "date" ? v : (v === "" ? null : Number(v));
+    });
+    if (!entry.date) {
+      alert("Please enter a date.");
+      return;
+    }
+    const list = Store.getMeasurements().filter((m) => m.date !== entry.date);
+    list.push(entry);
+    Store.saveMeasurements(list);
+    row.querySelectorAll("input").forEach((i) => (i.value = ""));
+    renderMeasurementsTable();
+  });
+}
+
+// ===================== Food Database =====================
+function renderFoods() {
+  const foods = Store.getFoods();
+  const tbody = document.getElementById("food-body");
+  tbody.innerHTML = "";
+  foods.forEach((f, idx) => {
+    const tr = document.createElement("tr");
+    tr.innerHTML = `
+      <td>${f.name}</td>
+      <td>${f.unit}</td>
+      <td>${f.cal}</td>
+      <td>${f.protein}</td>
+      <td>${f.carb}</td>
+      <td>${f.fat}</td>
+      <td>${f.fiber}</td>
+      <td>${f.sugar}</td>
+      <td><button class="delete-btn" data-idx="${idx}">✕</button></td>
+    `;
+    tr.querySelector(".delete-btn").addEventListener("click", () => {
+      const updated = Store.getFoods().filter((_, i) => i !== idx);
+      Store.saveFoods(updated);
+      renderFoods();
+    });
+    tbody.appendChild(tr);
+  });
+
+  // targets form
+  const t = Store.getTargets();
+  document.getElementById("t-calorie").value = t.calorie;
+  document.getElementById("t-protein").value = t.protein;
+  document.getElementById("t-carb").value = t.carb;
+  document.getElementById("t-fatmin").value = t.fatMin;
+  document.getElementById("t-fatmax").value = t.fatMax;
+  document.getElementById("t-fibermin").value = t.fiberMin;
+  document.getElementById("t-fibermax").value = t.fiberMax;
+}
+
+function initFoodForms() {
+  document.getElementById("add-food-btn").addEventListener("click", () => {
+    const row = document.getElementById("food-form-row");
+    const name = row.querySelector('[data-field="name"]').value.trim();
+    if (!name) {
+      alert("Please enter a food name.");
+      return;
+    }
+    const food = { name, unit: row.querySelector('[data-field="unit"]').value.trim() || "gm" };
+    ["cal", "protein", "carb", "fat", "fiber", "sugar"].forEach((f) => {
+      const v = row.querySelector(`[data-field="${f}"]`).value;
+      food[f] = v === "" ? 0 : Number(v);
+    });
+    const foods = Store.getFoods().filter((x) => x.name !== name);
+    foods.push(food);
+    Store.saveFoods(foods);
+    row.querySelectorAll("input").forEach((i) => {
+      if (i.dataset.field !== "unit") i.value = "";
+    });
+    renderFoods();
+    renderMealBuilder();
+  });
+
+  document.getElementById("save-targets-btn").addEventListener("click", () => {
+    const targets = {
+      calorie: Number(document.getElementById("t-calorie").value) || 0,
+      protein: Number(document.getElementById("t-protein").value) || 0,
+      carb: Number(document.getElementById("t-carb").value) || 0,
+      fatMin: Number(document.getElementById("t-fatmin").value) || 0,
+      fatMax: Number(document.getElementById("t-fatmax").value) || 0,
+      fiberMin: Number(document.getElementById("t-fibermin").value) || 0,
+      fiberMax: Number(document.getElementById("t-fibermax").value) || 0,
+    };
+    Store.saveTargets(targets);
+    renderTargetsReadout();
+    renderMealBuilder();
+    alert("Targets saved.");
+  });
+}
+
+// ===================== Init =====================
+document.addEventListener("DOMContentLoaded", () => {
+  initTabs();
+  initMealBuilder();
+  initHealthForms();
+  initFoodForms();
+});

--- a/calorie-tracker/js/foods.js
+++ b/calorie-tracker/js/foods.js
@@ -1,0 +1,24 @@
+// Default food database, extracted from the user's Excel macro sheet.
+// Each food's macro values are "per 1 unit" (see `unit`), so totals = value * quantity.
+const DEFAULT_FOODS = [
+  { name: "Egg",                      unit: "egg", cal: 70.0,   protein: 6.0,    carb: 0.0,    fat: 5.0,    fiber: 0.0,    sugar: 0.0 },
+  { name: "Egg White",                unit: "gm", cal: 0.54348, protein: 0.1087, carb: 0.0,    fat: 0.0,    fiber: 0.0,    sugar: 0.0 },
+  { name: "Baked walmart drumstick99",unit: "gm", cal: 1.63096, protein: 0.29411,carb: 0.0,    fat: 0.03636,fiber: 0.0,    sugar: 0.0 },
+  { name: "Baked Beef15",             unit: "gm", cal: 2.22355, protein: 0.30083,carb: 0.0,    fat: 0.08894,fiber: 0.0,    sugar: 0.0 },
+  { name: "Whole Moong Dal",          unit: "gm", cal: 3.46154, protein: 0.23077,carb: 0.61538,fat: 0.00962,fiber: 0.15385,sugar: 0.0 },
+  { name: "Rice",                     unit: "gm", cal: 3.55556, protein: 0.08889,carb: 0.8,    fat: 0.0,    fiber: 0.02222,sugar: 0.0 },
+  { name: "Broccoli",                 unit: "gm", cal: 0.38889, protein: 0.02556,carb: 0.06222,fat: 0.00333,fiber: 0.00333,sugar: 0.0 },
+  { name: "Palak",                    unit: "gm", cal: 0.23529, protein: 0.02353,carb: 0.03529,fat: 0.0,    fiber: 0.02353,sugar: 0.0 },
+  { name: "Beans",                    unit: "gm", cal: 0.31,    protein: 0.018,  carb: 0.07,   fat: 0.002,  fiber: 0.027,  sugar: 0.0 },
+  { name: "Onion",                    unit: "gm", cal: 0.4,     protein: 0.011,  carb: 0.093,  fat: 0.001,  fiber: 0.017,  sugar: 0.0 },
+  { name: "Tomato",                   unit: "gm", cal: 0.18,    protein: 0.009,  carb: 0.039,  fat: 0.002,  fiber: 0.012,  sugar: 0.0 },
+  { name: "Nature Own Bread",         unit: "gm", cal: 2.4,     protein: 0.16,   carb: 0.44,   fat: 0.04,   fiber: 0.08,   sugar: 0.0 },
+  { name: "Almonds",                  unit: "gm", cal: 5.66667, protein: 0.2,    carb: 0.2,    fat: 0.5,    fiber: 0.13333,sugar: 0.0 },
+  { name: "Walnut",                   unit: "gm", cal: 6.66667, protein: 0.16667,carb: 0.13333,fat: 0.66667,fiber: 0.06667,sugar: 0.0 },
+  { name: "Dates",                    unit: "gm", cal: 2.75,    protein: 0.025,  carb: 0.75,   fat: 0.0,    fiber: 0.075,  sugar: 0.0 },
+  { name: "Oats",                     unit: "gm", cal: 3.75,    protein: 0.125,  carb: 0.675,  fat: 0.0625, fiber: 0.075,  sugar: 0.0 },
+  { name: "Whey Protein",             unit: "scoop", cal: 120.0,protein: 24.0,  carb: 3.0,    fat: 1.5,    fiber: 0.0,    sugar: 1.0 },
+  { name: "Milk",                     unit: "gm", cal: 0.66667, protein: 0.03333,carb: 0.05,   fat: 0.03333,fiber: 0.0,    sugar: 0.05 },
+  { name: "Mango",                    unit: "gm", cal: 0.6,     protein: 0.00848,carb: 0.1497, fat: 0.00364,fiber: 0.01576,sugar: 0.0 },
+  { name: "Cow Ghee",                 unit: "gm", cal: 9.33333, protein: 0.0,    carb: 0.0,    fat: 0.73333,fiber: 0.0,    sugar: 0.0 },
+];

--- a/calorie-tracker/js/storage.js
+++ b/calorie-tracker/js/storage.js
@@ -1,0 +1,101 @@
+// Thin wrapper around localStorage for all app data.
+const STORAGE_KEYS = {
+  foods: "ct_foods",
+  meals: "ct_meals",          // { "YYYY-MM-DD": { "Breakfast": [{food, qty}], ... } }
+  weights: "ct_weights",      // { "YYYY-MM-DD": number }
+  measurements: "ct_measurements", // [{date, chest, bicepsL, bicepsR, hips, thighR, thighL, neck, forearmR, forearmL, wristR, wristL, shoulder, waist, pant, belly, weight, bfp}]
+  height: "ct_height",        // number (cm or inches, user's choice, stored as string)
+  targets: "ct_targets",      // { calorie, protein, carb, fatMin, fatMax, fiberMin, fiberMax }
+};
+
+const DEFAULT_TARGETS = {
+  calorie: 2000,
+  protein: 180,
+  carb: 200,
+  fatMin: 50,
+  fatMax: 55,
+  fiberMin: 25,
+  fiberMax: 30,
+};
+
+const SECTIONS = ["Breakfast", "Lunch", "Dinner", "Snack 1", "Snack 2", "Snack 3", "Evening Snack"];
+
+// Seed measurement entry from the user's existing tracking sheet.
+const DEFAULT_MEASUREMENTS = [
+  {
+    date: "2025-05-26", chest: 41, bicepsL: 15.5, bicepsR: 16, hips: 37,
+    thighR: 22, thighL: 21, neck: 14.6, forearmR: 12, forearmL: 11.5,
+    wristR: 7, wristL: 7, shoulder: 45.5, waist: 31.5, pant: 33.2,
+    belly: 33.8, weight: 164.6, bfp: 19.23663342,
+  },
+];
+
+function loadJSON(key, fallback) {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? JSON.parse(raw) : fallback;
+  } catch (e) {
+    console.error("Failed to load", key, e);
+    return fallback;
+  }
+}
+
+function saveJSON(key, value) {
+  localStorage.setItem(key, JSON.stringify(value));
+}
+
+const Store = {
+  getFoods() {
+    return loadJSON(STORAGE_KEYS.foods, DEFAULT_FOODS);
+  },
+  saveFoods(foods) {
+    saveJSON(STORAGE_KEYS.foods, foods);
+  },
+  getMeals() {
+    return loadJSON(STORAGE_KEYS.meals, {});
+  },
+  saveMeals(meals) {
+    saveJSON(STORAGE_KEYS.meals, meals);
+  },
+  getDayMeals(dateStr) {
+    const meals = this.getMeals();
+    if (!meals[dateStr]) {
+      meals[dateStr] = {};
+      SECTIONS.forEach((s) => (meals[dateStr][s] = []));
+    }
+    SECTIONS.forEach((s) => {
+      if (!meals[dateStr][s]) meals[dateStr][s] = [];
+    });
+    return meals[dateStr];
+  },
+  setDayMeals(dateStr, dayMeals) {
+    const meals = this.getMeals();
+    meals[dateStr] = dayMeals;
+    this.saveMeals(meals);
+  },
+  getWeights() {
+    return loadJSON(STORAGE_KEYS.weights, {});
+  },
+  saveWeights(weights) {
+    saveJSON(STORAGE_KEYS.weights, weights);
+  },
+  getMeasurements() {
+    return loadJSON(STORAGE_KEYS.measurements, DEFAULT_MEASUREMENTS);
+  },
+  saveMeasurements(list) {
+    saveJSON(STORAGE_KEYS.measurements, list);
+  },
+  getHeight() {
+    const v = localStorage.getItem(STORAGE_KEYS.height);
+    return v !== null ? v : "5' 7\"";
+  },
+  saveHeight(value) {
+    localStorage.setItem(STORAGE_KEYS.height, value);
+  },
+  getTargets() {
+    return loadJSON(STORAGE_KEYS.targets, DEFAULT_TARGETS);
+  },
+  saveTargets(targets) {
+    saveJSON(STORAGE_KEYS.targets, targets);
+  },
+};


### PR DESCRIPTION
## Summary
- Adds a static HTML/CSS/JS calorie & macro tracker (`calorie-tracker/`), no build step required
- **Meal Builder**: pick a date, add foods to Breakfast/Lunch/Dinner/Snack 1-3/Evening Snack, with live calorie & macro calculations vs daily targets (2000 kcal / 180g protein / 200g carb / 50-55g fat / 25-30g fiber)
- **7-Day Summary**: table of the last 7 days' totals, color-coded vs targets
- **Health Data**: static height field, daily weight log, fortnightly body-measurements table (seeded with 26 May entry)
- **Food Database**: 20 foods seeded from the user's Excel macro sheet, editable, with the ability to add new foods and adjust targets
- All data persists in the browser's localStorage

## Test plan
- [x] Verified in headless browser: meal builder adds items and computes correct calorie/macro totals (e.g. 2 eggs = 140 kcal / 12g protein)
- [x] Verified 7-Day Summary, Health Data, and Food Database tabs render correctly
- [ ] Open `calorie-tracker/index.html` in a browser and try building a real day's meals


---
_Generated by [Claude Code](https://claude.ai/code/session_019guoq1M9c61UzFJJSBeVsC)_