### PR TITLE
Add copy-meals-from-another-day feature

### DIFF
--- a/calorie-tracker/css/style.css
+++ b/calorie-tracker/css/style.css
@@ -177,7 +177,7 @@ button {
   font-family: inherit;
 }
 
-#save-height-btn, #add-weight-btn, #add-measurement-btn, #add-food-btn, #save-targets-btn {
+#save-height-btn, #add-weight-btn, #add-measurement-btn, #add-food-btn, #save-targets-btn, #copy-meals-btn {
   background: var(--primary);
   color: white;
   border: none;
@@ -187,7 +187,7 @@ button {
 }
 
 #save-height-btn:hover, #add-weight-btn:hover, #add-measurement-btn:hover,
-#add-food-btn:hover, #save-targets-btn:hover { background: var(--primary-dark); }
+#add-food-btn:hover, #save-targets-btn:hover, #copy-meals-btn:hover { background: var(--primary-dark); }
 
 .inline-form {
   display: flex;

--- a/calorie-tracker/index.html
+++ b/calorie-tracker/index.html
@@ -23,6 +23,9 @@
     <div class="panel-header">
       <label for="meal-date">Date:</label>
       <input type="date" id="meal-date" />
+      <label for="copy-date">Copy meals from:</label>
+      <input type="date" id="copy-date" />
+      <button id="copy-meals-btn">Copy to this day</button>
       <div class="targets-summary" id="targets-readout"></div>
     </div>
 

--- a/calorie-tracker/js/app.js
+++ b/calorie-tracker/js/app.js
@@ -79,10 +79,44 @@ function initMealBuilder() {
   dateInput.value = currentDate;
   dateInput.addEventListener("change", () => {
     currentDate = dateInput.value || todayStr();
+    updateCopyDateDefault();
     renderMealBuilder();
   });
+
+  updateCopyDateDefault();
+
+  document.getElementById("copy-meals-btn").addEventListener("click", () => {
+    const copyDate = document.getElementById("copy-date").value;
+    if (!copyDate) return;
+    if (copyDate === currentDate) {
+      alert("Pick a different date to copy from.");
+      return;
+    }
+    const sourceMeals = Store.getDayMeals(copyDate);
+    const hasItems = SECTIONS.some((s) => sourceMeals[s].length > 0);
+    if (!hasItems) {
+      alert(`No meals found on ${copyDate}.`);
+      return;
+    }
+    const targetMeals = Store.getDayMeals(currentDate);
+    SECTIONS.forEach((s) => {
+      sourceMeals[s].forEach((row) => {
+        targetMeals[s].push({ food: row.food, qty: row.qty });
+      });
+    });
+    Store.setDayMeals(currentDate, targetMeals);
+    renderMealBuilder();
+  });
+
   renderTargetsReadout();
   renderMealBuilder();
+}
+
+// Default the "copy from" date to the day before the currently selected date.
+function updateCopyDateDefault() {
+  const d = new Date(currentDate);
+  d.setDate(d.getDate() - 1);
+  document.getElementById("copy-date").value = d.toISOString().slice(0, 10);
 }
 
 function renderTargetsReadout() {


### PR DESCRIPTION
## Summary
- Adds a "Copy meals from" date picker + "Copy to this day" button in the Meal Builder
- Copies all food items (across all meal sections) from the chosen date into the currently selected day, appending to whatever's already there
- The "copy from" date defaults to the day before the currently selected date

## Test plan
- [x] Verified in headless browser: added 2 eggs on 06/10, switched to 06/11 (copy-from defaulted to 06/10), clicked "Copy to this day" — Breakfast and day totals updated correctly (140 kcal / 12g protein)


---
_Generated by [Claude Code](https://claude.ai/code/session_019guoq1M9c61UzFJJSBeVsC)_