### PR TITLE
Fix copy-meals template day not appearing for existing users

### DIFF
--- a/calorie-tracker/js/storage.js
+++ b/calorie-tracker/js/storage.js
@@ -93,7 +93,12 @@ const Store = {
     saveJSON(STORAGE_KEYS.foods, foods);
   },
   getMeals() {
-    return loadJSON(STORAGE_KEYS.meals, DEFAULT_MEALS);
+    const meals = loadJSON(STORAGE_KEYS.meals, DEFAULT_MEALS);
+    if (!meals[TEMPLATE_DATE]) {
+      meals[TEMPLATE_DATE] = DEFAULT_MEALS[TEMPLATE_DATE];
+      this.saveMeals(meals);
+    }
+    return meals;
   },
   saveMeals(meals) {
     saveJSON(STORAGE_KEYS.meals, meals);


### PR DESCRIPTION
## Summary
- Fixes "No meals found" when copying from the 2025-06-09 template day
- `getMeals()` previously only applied `DEFAULT_MEALS` (which contains the template day) when `ct_meals` did not exist in localStorage at all — existing users already had `ct_meals` set, so the template never appeared
- Now `getMeals()` always ensures the 2025-06-09 template day is present, merging it in and persisting if missing

## Test plan
- [x] Verified with Playwright: simulated existing `ct_meals` localStorage data, confirmed template day is merged in automatically and "Copy meals from" 2025-06-09 now copies meals correctly


---
_Generated by [Claude Code](https://claude.ai/code/session_019guoq1M9c61UzFJJSBeVsC)_