### PR TITLE
Fix stale food DB, copy-meals overwrite, and copy-date default

### DIFF
--- a/calorie-tracker/js/app.js
+++ b/calorie-tracker/js/app.js
@@ -100,9 +100,7 @@ function initMealBuilder() {
     }
     const targetMeals = Store.getDayMeals(currentDate);
     SECTIONS.forEach((s) => {
-      sourceMeals[s].forEach((row) => {
-        targetMeals[s].push({ food: row.food, qty: row.qty });
-      });
+      targetMeals[s] = sourceMeals[s].map((row) => ({ food: row.food, qty: row.qty }));
     });
     Store.setDayMeals(currentDate, targetMeals);
     renderMealBuilder();
@@ -112,9 +110,9 @@ function initMealBuilder() {
   renderMealBuilder();
 }
 
-// Default the "copy from" date to the day before the currently selected date.
+// Default the "copy from" date to yesterday.
 function updateCopyDateDefault() {
-  const d = new Date(currentDate);
+  const d = new Date();
   d.setDate(d.getDate() - 1);
   document.getElementById("copy-date").value = d.toISOString().slice(0, 10);
 }

--- a/calorie-tracker/js/storage.js
+++ b/calorie-tracker/js/storage.js
@@ -7,7 +7,11 @@ const STORAGE_KEYS = {
   height: "ct_height",        // number (cm or inches, user's choice, stored as string)
   targets: "ct_targets",      // { calorie, protein, carb, fatMin, fatMax, fiberMin, fiberMax }
   unitsMigrated: "ct_units_migrated_v1", // flag: meal qty values converted from old serving units to grams
+  foodsVersion: "ct_foods_version", // tracks which version of DEFAULT_FOODS has been merged in
 };
+
+// Bump this whenever DEFAULT_FOODS changes so existing users pick up the new values.
+const FOODS_VERSION = 2;
 
 const DEFAULT_TARGETS = {
   calorie: 2000,
@@ -550,7 +554,17 @@ function saveJSON(key, value) {
 
 const Store = {
   getFoods() {
-    return loadJSON(STORAGE_KEYS.foods, DEFAULT_FOODS);
+    const storedVersion = localStorage.getItem(STORAGE_KEYS.foodsVersion);
+    let foods = loadJSON(STORAGE_KEYS.foods, DEFAULT_FOODS);
+    if (storedVersion !== String(FOODS_VERSION)) {
+      // Refresh built-in foods with the latest values, keeping any custom foods the user added.
+      const defaultNames = new Set(DEFAULT_FOODS.map((f) => f.name));
+      const customFoods = foods.filter((f) => !defaultNames.has(f.name));
+      foods = [...DEFAULT_FOODS, ...customFoods];
+      this.saveFoods(foods);
+      localStorage.setItem(STORAGE_KEYS.foodsVersion, String(FOODS_VERSION));
+    }
+    return foods;
   },
   saveFoods(foods) {
     saveJSON(STORAGE_KEYS.foods, foods);
@@ -558,14 +572,14 @@ const Store = {
   getMeals() {
     const isNewUser = localStorage.getItem(STORAGE_KEYS.meals) === null;
     const meals = loadJSON(STORAGE_KEYS.meals, DEFAULT_MEALS);
-    if (!meals[TEMPLATE_DATE]) {
+    const templateInjected = !meals[TEMPLATE_DATE];
+    if (templateInjected) {
       meals[TEMPLATE_DATE] = DEFAULT_MEALS[TEMPLATE_DATE];
-      this.saveMeals(meals);
     }
     if (!isNewUser && !localStorage.getItem(STORAGE_KEYS.unitsMigrated)) {
       // Convert quantities for foods whose units changed from "Xg serving" to per-gram.
       Object.keys(meals).forEach((dateStr) => {
-        if (dateStr === TEMPLATE_DATE) return; // already stored in grams
+        if (dateStr === TEMPLATE_DATE && templateInjected) return; // freshly injected, already in grams
         Object.values(meals[dateStr]).forEach((rows) => {
           (rows || []).forEach((row) => {
             const grams = OLD_SERVING_GRAMS[row.food];
@@ -573,8 +587,8 @@ const Store = {
           });
         });
       });
-      this.saveMeals(meals);
     }
+    this.saveMeals(meals);
     localStorage.setItem(STORAGE_KEYS.unitsMigrated, "1");
     return meals;
   },


### PR DESCRIPTION
## Summary
- Fixes the food database not picking up the per-gram macro changes from PR #8 for existing users (browsers had a stale `ct_foods` saved). `getFoods()` now refreshes built-in foods from `DEFAULT_FOODS` when the bundled data changes, via a `FOODS_VERSION` flag, while preserving any custom foods the user added.
- Fixes the unit migration not running for the user's real meal data saved on 2025-06-09 (it happens to be the seeded template date, and the migration was skipping that date entirely).
- "Copy meals from" now **overwrites** the target day's sections instead of appending, so clicking it repeatedly no longer duplicates entries.
- The "Copy meals from" date now defaults to **yesterday** (relative to today) instead of the day before whichever date is selected in the meal builder.

## Test plan
- [x] Verified with Playwright: simulated stale `ct_foods` with old Egg White unit ("46g serving") — after reload, `Store.getFoods()` returns the updated per-gram value ("gm"), and a custom food the user added is preserved
- [x] Verified meal data saved on 2025-06-09 (the template date) with old serving-based quantities migrates correctly to grams
- [x] Verified clicking "Copy meals from" twice in a row produces the same (non-duplicated) result
- [x] Verified the "Copy meals from" field defaults to yesterday's date (2026-06-11)


---
_Generated by [Claude Code](https://claude.ai/code/session_019guoq1M9c61UzFJJSBeVsC)_