### PR TITLE
Fix 2025-06-09 unit migration for users who already loaded the app

### DIFF
--- a/calorie-tracker/js/storage.js
+++ b/calorie-tracker/js/storage.js
@@ -7,6 +7,7 @@ const STORAGE_KEYS = {
   height: "ct_height",        // number (cm or inches, user's choice, stored as string)
   targets: "ct_targets",      // { calorie, protein, carb, fatMin, fatMax, fiberMin, fiberMax }
   unitsMigrated: "ct_units_migrated_v1", // flag: meal qty values converted from old serving units to grams
+  templateUnitsMigrated: "ct_template_units_migrated_v1", // flag: TEMPLATE_DATE qty values converted
   foodsVersion: "ct_foods_version", // tracks which version of DEFAULT_FOODS has been merged in
 };
 
@@ -588,8 +589,19 @@ const Store = {
         });
       });
     }
+    if (!isNewUser && !templateInjected && !localStorage.getItem(STORAGE_KEYS.templateUnitsMigrated)) {
+      // The earlier migration skipped TEMPLATE_DATE on the assumption it was always freshly
+      // injected, but users with real data saved on that date never got converted. Fix it now.
+      Object.values(meals[TEMPLATE_DATE]).forEach((rows) => {
+        (rows || []).forEach((row) => {
+          const grams = OLD_SERVING_GRAMS[row.food];
+          if (grams) row.qty = Math.round(row.qty * grams * 100) / 100;
+        });
+      });
+    }
     this.saveMeals(meals);
     localStorage.setItem(STORAGE_KEYS.unitsMigrated, "1");
+    localStorage.setItem(STORAGE_KEYS.templateUnitsMigrated, "1");
     return meals;
   },
   saveMeals(meals) {


### PR DESCRIPTION
## Summary
- The previous PR's unit migration set a global `ct_units_migrated_v1` flag the first time it ran, which prevented the fix for the 2025-06-09 (template) date's quantities from ever running for users who had already loaded the app once after the per-gram switch — exactly your situation.
- Adds a dedicated, independent one-time migration that converts the 2025-06-09 day's quantities (e.g. Egg White 5.9348 → 273) without re-touching other dates that were already correctly migrated.

## Test plan
- [x] Verified with Playwright: simulated your exact state (unitsMigrated flag already set, other dates already in grams, 2025-06-09 still in old serving values) — after reload, 2025-06-09 converts correctly (Egg White 5.9348 → 273, Rice 0.6667 → 30) while 2025-06-10 is left untouched
- [x] Verified migration is idempotent across repeated reloads


---
_Generated by [Claude Code](https://claude.ai/code/session_019guoq1M9c61UzFJJSBeVsC)_