### PR TITLE
Fix idempotent template-date migration and add cache-busting

### DIFF
--- a/calorie-tracker/index.html
+++ b/calorie-tracker/index.html
@@ -192,8 +192,8 @@
   <p>All data is stored locally in your browser (localStorage).</p>
 </footer>
 
-<script src="js/foods.js"></script>
-<script src="js/storage.js"></script>
-<script src="js/app.js"></script>
+<script src="js/foods.js?v=11"></script>
+<script src="js/storage.js?v=11"></script>
+<script src="js/app.js?v=11"></script>
 </body>
 </html>

--- a/calorie-tracker/js/storage.js
+++ b/calorie-tracker/js/storage.js
@@ -65,6 +65,31 @@ const DEFAULT_MEALS = {
   },
 };
 
+// The TEMPLATE_DATE quantities as they were before the per-gram unit conversion (PR#8),
+// keyed by food name. Used to detect whether a user's saved TEMPLATE_DATE entry still
+// has the old serving-based quantities, so the migration can be applied exactly once
+// regardless of when it ran relative to the main unit migration.
+const OLD_TEMPLATE_QTY = {
+  "Egg White": [5.9348],
+  "Baked Walmart drumstick99": [0.2179],
+  "Baked Beef15": [0.2121],
+  "whole moong dal": [1.5385],
+  "Rice": [0.6667],
+  "Broccoli": [0.3],
+  "Palak": [0.3529],
+  "Beans": [0.3],
+  "Onion": [0.5],
+  "Tomato": [0.5],
+  "nature own bread": [2.4],
+  "Almonds": [0.1],
+  "Walnut": [0.1],
+  "Dates": [0.75],
+  "Oats": [1],
+  "Milk": [0.5, 0.8333],
+  "Mango": [0.9091],
+  "cow ghee": [0.6667],
+};
+
 // Maps food names to their old per-serving gram size, used once to migrate
 // existing meal quantities from the old "servings" units to grams.
 const OLD_SERVING_GRAMS = {
@@ -591,11 +616,15 @@ const Store = {
     }
     if (!isNewUser && !templateInjected && !localStorage.getItem(STORAGE_KEYS.templateUnitsMigrated)) {
       // The earlier migration skipped TEMPLATE_DATE on the assumption it was always freshly
-      // injected, but users with real data saved on that date never got converted. Fix it now.
+      // injected, but users with real data saved on that date never got converted. Only convert
+      // rows whose quantity still matches the old serving-based template value, so this stays
+      // idempotent whether or not the main migration above already converted this date.
       Object.values(meals[TEMPLATE_DATE]).forEach((rows) => {
         (rows || []).forEach((row) => {
           const grams = OLD_SERVING_GRAMS[row.food];
-          if (grams) row.qty = Math.round(row.qty * grams * 100) / 100;
+          const oldQtys = OLD_TEMPLATE_QTY[row.food];
+          const isOldQty = oldQtys && oldQtys.some((q) => Math.abs(row.qty - q) < 0.0001);
+          if (grams && isOldQty) row.qty = Math.round(row.qty * grams * 100) / 100;
         });
       });
     }


### PR DESCRIPTION
## Problem

After PR #10, the 2025-06-09 template entries still showed old serving-based quantities (e.g. Egg White qty=5.9348, cal=3.2) instead of the gram-based values (qty=273, cal~148).

Two likely causes:
1. **Migration ordering bug**: depending on when a user's data was originally saved relative to the unit migration flags, PR #10's dedicated `templateUnitsMigrated` migration could either never run, or run a *second* time on data that was already converted (multiplying an already-correct gram value by the gram conversion factor again, e.g. 273 → 12558).
2. **Stale cached JS**: GitHub Pages/browsers may serve cached `js/*.js` files without picking up the new code after a deploy.

## Fix

- Added `OLD_TEMPLATE_QTY`, a map of the original (pre-PR#8) serving-based quantities for each TEMPLATE_DATE food.
- The TEMPLATE_DATE migration now only converts a row's quantity if it still matches one of these old values — making the migration safe to run regardless of prior migration state (idempotent, no double-conversion, no missed conversion).
- Added `?v=11` cache-busting query strings to the `<script>` tags in `index.html` so updated JS is fetched after each deploy.

## Testing

Ran Playwright tests covering:
- Fresh unmigrated TEMPLATE_DATE data → converts to grams correctly (Egg White 273, Rice 30)
- Already-migrated TEMPLATE_DATE data (simulating prior successful migration) → stays unchanged, no double conversion
- Other dates already in grams → unchanged
- Idempotent across repeated reloads
- Existing food-version and copy-meals tests still pass


---
_Generated by [Claude Code](https://claude.ai/code/session_019guoq1M9c61UzFJJSBeVsC)_