### PR TITLE
Move 06/12 meals to 06/11, add weekend copy button and 7-day quick picks

### DIFF
--- a/calorie-tracker/css/style.css
+++ b/calorie-tracker/css/style.css
@@ -101,6 +101,33 @@ main {
   color: var(--muted);
 }
 
+.quick-dates {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.quick-date-btn {
+  padding: 0.3rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: #fff;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.quick-date-btn:hover { background: var(--primary-dark); color: #fff; }
+
+#copy-weekend-btn {
+  padding: 0.4rem 0.8rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: #fff;
+  cursor: pointer;
+}
+
+#copy-weekend-btn:hover { background: var(--primary-dark); color: #fff; }
+
 .section-card {
   background: var(--card-bg);
   border-radius: 10px;

--- a/calorie-tracker/index.html
+++ b/calorie-tracker/index.html
@@ -26,6 +26,8 @@
       <label for="copy-date">Copy meals from:</label>
       <input type="date" id="copy-date" />
       <button id="copy-meals-btn">Copy to this day</button>
+      <button id="copy-weekend-btn"></button>
+      <div id="last-7-days" class="quick-dates"></div>
       <div class="targets-summary" id="targets-readout"></div>
     </div>
 
@@ -192,8 +194,8 @@
   <p>All data is stored locally in your browser (localStorage).</p>
 </footer>
 
-<script src="js/foods.js?v=11"></script>
-<script src="js/storage.js?v=11"></script>
-<script src="js/app.js?v=11"></script>
+<script src="js/foods.js?v=12"></script>
+<script src="js/storage.js?v=12"></script>
+<script src="js/app.js?v=12"></script>
 </body>
 </html>

--- a/calorie-tracker/js/app.js
+++ b/calorie-tracker/js/app.js
@@ -86,28 +86,69 @@ function initMealBuilder() {
   updateCopyDateDefault();
 
   document.getElementById("copy-meals-btn").addEventListener("click", () => {
-    const copyDate = document.getElementById("copy-date").value;
-    if (!copyDate) return;
-    if (copyDate === currentDate) {
-      alert("Pick a different date to copy from.");
-      return;
-    }
-    const sourceMeals = Store.getDayMeals(copyDate);
-    const hasItems = SECTIONS.some((s) => sourceMeals[s].length > 0);
-    if (!hasItems) {
-      alert(`No meals found on ${copyDate}.`);
-      return;
-    }
-    const targetMeals = Store.getDayMeals(currentDate);
-    SECTIONS.forEach((s) => {
-      targetMeals[s] = sourceMeals[s].map((row) => ({ food: row.food, qty: row.qty }));
-    });
-    Store.setDayMeals(currentDate, targetMeals);
-    renderMealBuilder();
+    copyMealsFrom(document.getElementById("copy-date").value);
   });
 
+  document.getElementById("copy-weekend-btn").addEventListener("click", () => {
+    copyMealsFrom(mostRecentSundayStr());
+  });
+
+  renderLast7DaysQuickPicks();
+  renderCopyWeekendBtn();
   renderTargetsReadout();
   renderMealBuilder();
+}
+
+// Copies the meals from `copyDate` onto `currentDate`, overwriting any existing entries.
+function copyMealsFrom(copyDate) {
+  if (!copyDate) return;
+  if (copyDate === currentDate) {
+    alert("Pick a different date to copy from.");
+    return;
+  }
+  const sourceMeals = Store.getDayMeals(copyDate);
+  const hasItems = SECTIONS.some((s) => sourceMeals[s].length > 0);
+  if (!hasItems) {
+    alert(`No meals found on ${copyDate}.`);
+    return;
+  }
+  const targetMeals = Store.getDayMeals(currentDate);
+  SECTIONS.forEach((s) => {
+    targetMeals[s] = sourceMeals[s].map((row) => ({ food: row.food, qty: row.qty }));
+  });
+  Store.setDayMeals(currentDate, targetMeals);
+  renderMealBuilder();
+}
+
+// Returns the date string (YYYY-MM-DD) of the most recent Sunday (today counts if it's Sunday).
+function mostRecentSundayStr() {
+  const d = new Date();
+  d.setDate(d.getDate() - d.getDay());
+  return d.toISOString().slice(0, 10);
+}
+
+function renderCopyWeekendBtn() {
+  const date = mostRecentSundayStr();
+  const btn = document.getElementById("copy-weekend-btn");
+  btn.textContent = `Copy from Weekend - (${date})`;
+}
+
+// Quick-pick buttons to set the "Copy meals from" date to one of the last 7 days.
+function renderLast7DaysQuickPicks() {
+  const container = document.getElementById("last-7-days");
+  container.innerHTML = "";
+  for (let i = 1; i <= 7; i++) {
+    const d = new Date();
+    d.setDate(d.getDate() - i);
+    const dateStr = d.toISOString().slice(0, 10);
+    const btn = document.createElement("button");
+    btn.className = "quick-date-btn";
+    btn.textContent = dateStr;
+    btn.addEventListener("click", () => {
+      document.getElementById("copy-date").value = dateStr;
+    });
+    container.appendChild(btn);
+  }
 }
 
 // Default the "copy from" date to yesterday.

--- a/calorie-tracker/js/storage.js
+++ b/calorie-tracker/js/storage.js
@@ -9,7 +9,12 @@ const STORAGE_KEYS = {
   unitsMigrated: "ct_units_migrated_v1", // flag: meal qty values converted from old serving units to grams
   templateUnitsMigrated: "ct_template_units_migrated_v1", // flag: TEMPLATE_DATE qty values converted
   foodsVersion: "ct_foods_version", // tracks which version of DEFAULT_FOODS has been merged in
+  jun12MovedToJun11: "ct_2026_06_12_moved_to_06_11_v1", // flag: 2026-06-12 entries moved to 2026-06-11
 };
+
+// One-time move of meals entered under 2026-06-12 to 2026-06-11 (they were meant for that day).
+const MOVE_DATE_FROM = "2026-06-12";
+const MOVE_DATE_TO = "2026-06-11";
 
 // Bump this whenever DEFAULT_FOODS changes so existing users pick up the new values.
 const FOODS_VERSION = 2;
@@ -628,9 +633,17 @@ const Store = {
         });
       });
     }
+    if (!isNewUser && meals[MOVE_DATE_FROM] && !localStorage.getItem(STORAGE_KEYS.jun12MovedToJun11)) {
+      meals[MOVE_DATE_TO] = meals[MOVE_DATE_TO] || {};
+      SECTIONS.forEach((s) => {
+        meals[MOVE_DATE_TO][s] = (meals[MOVE_DATE_TO][s] || []).concat(meals[MOVE_DATE_FROM][s] || []);
+      });
+      delete meals[MOVE_DATE_FROM];
+    }
     this.saveMeals(meals);
     localStorage.setItem(STORAGE_KEYS.unitsMigrated, "1");
     localStorage.setItem(STORAGE_KEYS.templateUnitsMigrated, "1");
+    localStorage.setItem(STORAGE_KEYS.jun12MovedToJun11, "1");
     return meals;
   },
   saveMeals(meals) {


### PR DESCRIPTION
## Changes

- **One-time data move**: any meals saved under 2026-06-12 are moved to 2026-06-11 (they were meant for that day).
- **"Copy from Weekend" button**: new button labeled "Copy from Weekend - (YYYY-MM-DD)" that copies meals from the most recent Sunday into the currently selected day, overwriting existing entries (same behavior as the existing copy button).
- **Last 7 days quick picks**: row of small date buttons for the last 7 days; clicking one fills the "Copy meals from" date field so you can quickly copy from any recent day.

## Testing

Playwright tests verify:
- 2026-06-12 meals are moved to 2026-06-11 and the migration is idempotent across reloads
- The weekend button shows the correct most-recent-Sunday date
- The 7 quick-pick buttons show the correct last 7 dates and clicking one updates the copy-date field
- Existing template migration and copy-overwrite tests still pass


---
_Generated by [Claude Code](https://claude.ai/code/session_019guoq1M9c61UzFJJSBeVsC)_