### PR TITLE
Widen page to remove Body Measurements table scrollbar

### DIFF
--- a/calorie-tracker/css/style.css
+++ b/calorie-tracker/css/style.css
@@ -56,7 +56,7 @@ body {
 .tab-btn.active { background: var(--primary); font-weight: 600; }
 
 main {
-  max-width: 1100px;
+  max-width: 1600px;
   margin: 0 auto;
   padding: 1.25rem;
 }


### PR DESCRIPTION
## Change

Increased the page's max-width from 1100px to 1600px so the Body Measurements table (14 fields + delete button) fits without a horizontal scrollbar on typical desktop screens.

## Testing

Verified via Playwright at 1920px viewport: the measurements table's `scrollWidth` now equals its `clientWidth` (1520px), confirming no horizontal scrollbar.


---
_Generated by [Claude Code](https://claude.ai/code/session_019guoq1M9c61UzFJJSBeVsC)_