### PR TITLE
Add Baked Walmart drumstick100 and Baked Beef16 to food database

### DIFF
--- a/calorie-tracker/index.html
+++ b/calorie-tracker/index.html
@@ -194,8 +194,8 @@
   <p>All data is stored locally in your browser (localStorage).</p>
 </footer>
 
-<script src="js/foods.js?v=12"></script>
-<script src="js/storage.js?v=12"></script>
-<script src="js/app.js?v=12"></script>
+<script src="js/foods.js?v=13"></script>
+<script src="js/storage.js?v=13"></script>
+<script src="js/app.js?v=13"></script>
 </body>
 </html>

--- a/calorie-tracker/js/foods.js
+++ b/calorie-tracker/js/foods.js
@@ -473,5 +473,7 @@ const DEFAULT_FOODS = [
   { name: "Raw Beef15", unit: "gm", cal: 1.51786, protein: 0.20536, carb: 0, fat: 0.07143, fiber: 0, sugar: 0 },
   { name: "Baked Beef15", unit: "gm", cal: 2.22355, protein: 0.30083, carb: 0, fat: 0.08894, fiber: 0, sugar: 0 },
   { name: "Raw Walmart drumstick100", unit: "gm", cal: 1.08929, protein: 0.19643, carb: 0, fat: 0.02857, fiber: 0, sugar: 0 },
+  { name: "Baked Walmart drumstick100", unit: "gm", cal: 1.52014, protein: 0.27412, carb: 0, fat: 0.03389, fiber: 0, sugar: 0 },
   { name: "Raw Beef16", unit: "gm", cal: 1.51786, protein: 0.20536, carb: 0, fat: 0.07143, fiber: 0, sugar: 0 },
+  { name: "Baked Beef16", unit: "gm", cal: 2.13913, protein: 0.28941, carb: 0, fat: 0.08557, fiber: 0, sugar: 0 },
 ];

--- a/calorie-tracker/js/storage.js
+++ b/calorie-tracker/js/storage.js
@@ -17,7 +17,7 @@ const MOVE_DATE_FROM = "2026-06-12";
 const MOVE_DATE_TO = "2026-06-11";
 
 // Bump this whenever DEFAULT_FOODS changes so existing users pick up the new values.
-const FOODS_VERSION = 2;
+const FOODS_VERSION = 3;
 
 const DEFAULT_TARGETS = {
   calorie: 2000,


### PR DESCRIPTION
## Change

Adds two missing food entries to the database:
- `Baked Walmart drumstick100` — cal 1.52014, protein 0.27412, fat 0.03389 per gram
- `Baked Beef16` — cal 2.13913, protein 0.28941, fat 0.08557 per gram

Per-gram values derived from the provided totals (e.g. Baked Walmart drumstick100: 1906.25 cal / 343.75 protein / 42.5 fat for a 1254g baked portion), consistent with how the existing `Baked Walmart drumstick99` / `Baked Beef15` entries were computed.

Bumped `FOODS_VERSION` to 3 so existing users automatically pick up the new entries.

## Testing

Playwright test confirms `Store.getFoods()` returns both new entries with the expected per-gram macros after the version bump.


---
_Generated by [Claude Code](https://claude.ai/code/session_019guoq1M9c61UzFJJSBeVsC)_