### PR TITLE
Compute calories from macros (P*4 + C*4 + F*9)

### DIFF
--- a/calorie-tracker/index.html
+++ b/calorie-tracker/index.html
@@ -194,8 +194,8 @@
   <p>All data is stored locally in your browser (localStorage).</p>
 </footer>
 
-<script src="js/foods.js?v=13"></script>
-<script src="js/storage.js?v=13"></script>
-<script src="js/app.js?v=13"></script>
+<script src="js/foods.js?v=14"></script>
+<script src="js/storage.js?v=14"></script>
+<script src="js/app.js?v=14"></script>
 </body>
 </html>

--- a/calorie-tracker/js/app.js
+++ b/calorie-tracker/js/app.js
@@ -13,15 +13,24 @@ function getFoodByName(name) {
   return Store.getFoods().find((f) => f.name === name);
 }
 
+// Atwater factors: calories are derived from macros rather than taken from food labels,
+// since label calorie values are often inconsistent with their own macro breakdowns.
+function caloriesFromMacros(protein, carb, fat) {
+  return protein * 4 + carb * 4 + fat * 9;
+}
+
 function computeRowMacros(row) {
   const food = getFoodByName(row.food);
   const qty = Number(row.qty) || 0;
   if (!food) return { cal: 0, protein: 0, carb: 0, fat: 0, fiber: 0, sugar: 0 };
+  const protein = food.protein * qty;
+  const carb = food.carb * qty;
+  const fat = food.fat * qty;
   return {
-    cal: food.cal * qty,
-    protein: food.protein * qty,
-    carb: food.carb * qty,
-    fat: food.fat * qty,
+    cal: caloriesFromMacros(protein, carb, fat),
+    protein,
+    carb,
+    fat,
     fiber: food.fiber * qty,
     sugar: food.sugar * qty,
   };
@@ -500,7 +509,7 @@ function renderFoods() {
     tr.innerHTML = `
       <td>${f.name}</td>
       <td>${f.unit}</td>
-      <td>${f.cal}</td>
+      <td>${fmt(caloriesFromMacros(f.protein, f.carb, f.fat), 2)}</td>
       <td>${f.protein}</td>
       <td>${f.carb}</td>
       <td>${f.fat}</td>


### PR DESCRIPTION
## Change

Calories are now computed as `protein*4 + carb*4 + fat*9` (Atwater factors) instead of using each food's stored `cal` label value, since package label calorie values are often inconsistent with their own macro breakdowns.

This affects:
- Meal row calorie cells
- Section subtotals and day totals
- The Food Database "Calories" column (now derived from protein/carb/fat per unit)

## Testing

Playwright verified e.g. Egg White 315g now shows 136.96 cal (34.24g protein * 4) instead of the old label-based 171.2. Existing migration/copy tests still pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_019guoq1M9c61UzFJJSBeVsC)_